### PR TITLE
Fix crash in GLX backend

### DIFF
--- a/EGL/src/egl_common.c
+++ b/EGL/src/egl_common.c
@@ -1685,7 +1685,7 @@ EGLDisplay _eglGetDisplay(EGLNativeDisplayType display_id)
 
 	newDpy->initialized = EGL_FALSE;
 	newDpy->destroy = EGL_FALSE;
-	newDpy->display_id = display_id;
+	newDpy->display_id = display_id ? display_id : g_localStorage.dummy.display;
 	newDpy->rootSurface = 0;
 	newDpy->rootCtx = 0;
 	newDpy->rootConfig = 0;


### PR DESCRIPTION
It seems that EGLDisplayImpl's display_id member gets
set to 0x0 when eglGetDisplay is called with
EGL_DEFAULT_DISPLAY. Some other code attempts
to dereference this pointer by passing it to XLib's
DefaultScreen() macro, leading to a crash. This patch
fixes the issue for me.